### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to Retinbox Web Hosting
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Braydenccc/SeatingChartEditor2/security/code-scanning/2](https://github.com/Braydenccc/SeatingChartEditor2/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions` block for the workflow or for individual jobs so that the `GITHUB_TOKEN` has only the minimal scopes required. For this workflow, both jobs only need to read repository contents (for checkout) and do not appear to need any write operations to the GitHub API, so setting `contents: read` is a safe least‑privilege baseline. If any job later needs extra scopes, they can be added locally for that job.

The single best fix without changing existing functionality is to add a workflow‑level `permissions` block directly under the `name` (and before `on:`) in `.github/workflows/deploy.yml`, specifying `contents: read`. This will apply to both `deploy-production` and `deploy-staging` unless they override it with their own `permissions`. No other parts of the file need to change, and no new methods or imports are required because `permissions` is a native GitHub Actions workflow key.

Concretely: edit `.github/workflows/deploy.yml` and insert:

```yml
permissions:
  contents: read
```

between lines 1 and 3 (after `name: Deploy to Retinbox Web Hosting` and its following blank line). This satisfies CodeQL’s recommendation by explicitly restricting `GITHUB_TOKEN` to read‑only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Define a workflow-level permissions block in the deploy GitHub Actions workflow, limiting GITHUB_TOKEN to read-only repository contents.