### PR TITLE
fix: add error handling for JSON.parse in useCloudWorkspace (#55)

### DIFF
--- a/src/composables/__tests__/useCloudWorkspace.test.js
+++ b/src/composables/__tests__/useCloudWorkspace.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useCloudWorkspace } from '../useCloudWorkspace'
+
+const {
+  mockListFiles,
+  mockPutFile,
+  mockGetFileText,
+  mockDeleteFile,
+  mockFetchWithRetry,
+  mockLoggerError,
+  mockCurrentUser,
+  mockToken,
+  mockAuthType,
+  mockWebdavConfig,
+  mockBackupMode
+} = vi.hoisted(() => ({
+  mockListFiles: vi.fn(),
+  mockPutFile: vi.fn(),
+  mockGetFileText: vi.fn(),
+  mockDeleteFile: vi.fn(),
+  mockFetchWithRetry: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockCurrentUser: { value: { username: 'tester' } },
+  mockToken: { value: 'token' },
+  mockAuthType: { value: 'retiehe' },
+  mockWebdavConfig: { value: { baseUrl: 'https://example.com' } },
+  mockBackupMode: { value: false }
+}))
+
+vi.mock('../useAuth', () => ({
+  useAuth: () => ({
+    currentUser: mockCurrentUser,
+    token: mockToken,
+    authType: mockAuthType,
+    webdavConfig: mockWebdavConfig,
+    backupMode: mockBackupMode
+  }),
+  getOrCreateCsrfToken: () => 'csrf-token'
+}))
+
+vi.mock('../useWebDav', () => ({
+  useWebDav: () => ({
+    listFiles: mockListFiles,
+    putFile: mockPutFile,
+    getFileText: mockGetFileText,
+    deleteFile: mockDeleteFile
+  })
+}))
+
+vi.mock('@/utils/fetchHelpers', () => ({
+  fetchWithRetry: mockFetchWithRetry
+}))
+
+vi.mock('../useLogger', () => ({
+  useLogger: () => ({
+    error: mockLoggerError
+  })
+}))
+
+describe('useCloudWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCurrentUser.value = { username: 'tester' }
+    mockToken.value = 'token'
+    mockAuthType.value = 'retiehe'
+    mockWebdavConfig.value = { baseUrl: 'https://example.com' }
+    mockBackupMode.value = false
+  })
+
+  it('should return message on invalid JSON and stop save flow', async () => {
+    const cloudWorkspace = useCloudWorkspace()
+
+    await expect(
+      cloudWorkspace.saveWorkspaceToCloud('invalid-json', '{invalid json')
+    ).resolves.toEqual({
+      success: false,
+      message: '工作区数据格式错误',
+      error: '工作区数据格式错误'
+    })
+
+    expect(mockLoggerError).toHaveBeenCalledWith('工作区数据格式错误')
+    expect(mockFetchWithRetry).not.toHaveBeenCalled()
+    expect(mockPutFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/composables/useCloudWorkspace.js
+++ b/src/composables/useCloudWorkspace.js
@@ -3,6 +3,7 @@ import { useAuth } from './useAuth'
 import { useWebDav } from './useWebDav'
 import { getOrCreateCsrfToken } from './useAuth'
 import { fetchWithRetry } from '@/utils/fetchHelpers'
+import { useLogger } from './useLogger'
 
 export function useCloudWorkspace() {
     const { currentUser, token, authType, webdavConfig, backupMode } = useAuth()
@@ -147,7 +148,14 @@ export function useCloudWorkspace() {
 
     // Save a workspace
     const saveWorkspaceToCloud = async (name, content, fileId = null, target = authType.value) => {
-        const parsedContent = typeof content === 'string' ? JSON.parse(content) : content
+        let parsedContent
+        try {
+            parsedContent = typeof content === 'string' ? JSON.parse(content) : content
+        } catch (e) {
+            console.error('Failed to parse workspace content:', e)
+            useLogger().error('工作区数据格式错误')
+            return { success: false, error: '工作区数据格式错误' }
+        }
         const jsonStr = typeof content === 'string' ? content : JSON.stringify(content, null, 2)
         
         if (target === 'webdav' && !(backupMode.value && currentUser.value)) {

--- a/src/composables/useCloudWorkspace.js
+++ b/src/composables/useCloudWorkspace.js
@@ -8,6 +8,7 @@ import { useLogger } from './useLogger'
 export function useCloudWorkspace() {
     const { currentUser, token, authType, webdavConfig, backupMode } = useAuth()
     const { listFiles, putFile, getFileText, deleteFile } = useWebDav()
+    const { error } = useLogger()
     const isFetching = ref(false)
 
     // 获取与更新 WebDAV 设置 (例如导出路径)
@@ -153,8 +154,8 @@ export function useCloudWorkspace() {
             parsedContent = typeof content === 'string' ? JSON.parse(content) : content
         } catch (e) {
             console.error('Failed to parse workspace content:', e)
-            useLogger().error('工作区数据格式错误')
-            return { success: false, error: '工作区数据格式错误' }
+            error('工作区数据格式错误')
+            return { success: false, message: '工作区数据格式错误', error: '工作区数据格式错误' }
         }
         const jsonStr = typeof content === 'string' ? content : JSON.stringify(content, null, 2)
         

--- a/src/composables/useCloudWorkspace.js
+++ b/src/composables/useCloudWorkspace.js
@@ -5,6 +5,8 @@ import { getOrCreateCsrfToken } from './useAuth'
 import { fetchWithRetry } from '@/utils/fetchHelpers'
 import { useLogger } from './useLogger'
 
+const workspaceFormatErrorMessage = '工作区数据格式错误'
+
 export function useCloudWorkspace() {
     const { currentUser, token, authType, webdavConfig, backupMode } = useAuth()
     const { listFiles, putFile, getFileText, deleteFile } = useWebDav()
@@ -154,8 +156,8 @@ export function useCloudWorkspace() {
             parsedContent = typeof content === 'string' ? JSON.parse(content) : content
         } catch (e) {
             console.error('Failed to parse workspace content:', e)
-            error('工作区数据格式错误')
-            return { success: false, message: '工作区数据格式错误', error: '工作区数据格式错误' }
+            error(workspaceFormatErrorMessage)
+            return { success: false, message: workspaceFormatErrorMessage, error: workspaceFormatErrorMessage }
         }
         const jsonStr = typeof content === 'string' ? content : JSON.stringify(content, null, 2)
         


### PR DESCRIPTION
## Summary
- Add try-catch around JSON.parse on line 151
- Return error response with user-friendly message
- Prevents app crash when workspace data is corrupted

## Test plan
- All unit tests pass (129/129)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add defensive error handling when saving cloud workspaces to avoid crashes on invalid JSON content.

Bug Fixes:
- Prevent cloud workspace saving from crashing the app when workspace content JSON parsing fails.

Enhancements:
- Add structured logging for workspace data format errors when saving to the cloud.